### PR TITLE
version 1.0.0

### DIFF
--- a/lib/GPH.pm
+++ b/lib/GPH.pm
@@ -3,6 +3,6 @@ package GPH;
 use strict;
 use warnings FATAL => 'all';
 
-our $VERSION = '0.0.1';
+our $VERSION = '1.0.0';
 
 1;

--- a/lib/GPH/Gitlab.pm
+++ b/lib/GPH/Gitlab.pm
@@ -99,16 +99,6 @@ sub getBlacklistPaths {
 }
 
 #------------------------------------------------------------------------------
-# Get owner paths reference
-#
-# Returns: reference to array of code owner paths
-sub getPathsReference {
-    my $self = shift;
-
-    return \$self->{codeowners}->{$self->{owner}};
-}
-
-#------------------------------------------------------------------------------
 # Get owner paths as comma separated path list
 #
 # Returns: comma separated string of code owner paths


### PR DESCRIPTION
- bumped version to 1.0.0
- deprecated Gitlab::getPathsReference method